### PR TITLE
fix: update flagReader Read method and go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/conf-reader-flags
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/spf13/pflag v1.0.6

--- a/reader.go
+++ b/reader.go
@@ -17,7 +17,7 @@ func (r *flagReader) Prefix() string {
 	return r.prefix
 }
 
-func (r *flagReader) Read(ctx context.Context) (any, error) {
+func (r *flagReader) Read(_ context.Context) (any, error) {
 	res := map[string]string{}
 	for name, key := range r.mapFlagKey {
 		if fl := r.flagSet.Lookup(name); fl != nil {
@@ -25,7 +25,7 @@ func (r *flagReader) Read(ctx context.Context) (any, error) {
 		}
 	}
 
-	return res, ctx.Err()
+	return res, nil
 }
 
 // New creates the Env reader


### PR DESCRIPTION
Change Go version from 1.24.0 to 1.24 for consistency.  
Modify flagReader.Read to ignore the context parameter and always  
return nil error instead of ctx.Err(). This ensures reliable flag  
reading without unnecessary context cancellation checks.